### PR TITLE
fix a bug in the spyder download

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ https://github.com/conda-forge/pyqt-feedstock/issues/19
 conda install -c defaults pyqt=5 qt
 ```
 
+REMEMBER TO type `y` to accept these installations!
+
 Now to test that it has worked type:
 ```bash
 spyder

--- a/README.md
+++ b/README.md
@@ -51,3 +51,19 @@ A long and terrifying list of things will appear.
 Just type `y` to accept the installation of these packages.
 
 Let these install.
+
+There is a problem with the Spyder Installation.
+https://github.com/conda-forge/pyqt-feedstock/issues/19
+```bash
+conda install -c defaults pyqt=5 qt
+```
+
+Now to test that it has worked type:
+```bash
+spyder
+```
+hit enter and a few dialogue boxes will open. Accept them all.
+
+Then you should get a window that looks like this:
+
+https://raw.githubusercontent.com/spyder-ide/conda-manager/master/img_src/screenshot-spyder.png


### PR DESCRIPTION
https://github.com/conda-forge/pyqt-feedstock/issues/19

Error:
```
 ➜  ~ spyder                                          [system]
Traceback (most recent call last):
  File "/Users/TommyLees/anaconda3/envs/weather_station/lib/python3.6/site-packages/qtpy/QtWebEngineWidgets.py", line 22, in <module>
    from PyQt5.QtWebEngineWidgets import QWebEnginePage
ModuleNotFoundError: No module named 'PyQt5.QtWebEngineWidgets'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/TommyLees/anaconda3/envs/weather_station/bin/spyder", line 11, in <module>
    sys.exit(main())
  File "/Users/TommyLees/anaconda3/envs/weather_station/lib/python3.6/site-packages/spyder/app/start.py", line 189, in main
    from spyder.app import mainwindow
  File "/Users/TommyLees/anaconda3/envs/weather_station/lib/python3.6/site-packages/spyder/app/mainwindow.py", line 92, in <module>
    from qtpy import QtWebEngineWidgets  # analysis:ignore
  File "/Users/TommyLees/anaconda3/envs/weather_station/lib/python3.6/site-packages/qtpy/QtWebEngineWidgets.py", line 26, in <module>
    from PyQt5.QtWebKitWidgets import QWebPage as QWebEnginePage
ModuleNotFoundError: No module named 'PyQt5.QtWebKitWidgets'
```